### PR TITLE
Breadcrumb management

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -281,7 +281,6 @@ header .breadcrumbs {
   padding: 0 32px;
   width: 100%;
   height: var(--breadcrumbs-height);
-  max-width: 1200px;
   overflow: hidden;
   margin: 0 auto;
   font-size: var(--breadcrumbs-font-size);

--- a/plusplus/src/reModelDom.js
+++ b/plusplus/src/reModelDom.js
@@ -24,7 +24,7 @@ export function removeMeta() {
     'theme',
     'template',
     'footer',
-
+    'breadcrumbs',
   ];
   const elements = document.querySelectorAll('meta[name]');
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -39,6 +39,8 @@
 
   /* nav height */
   --nav-height: 64px;
+  --breadcrumbs-height: 35px;
+  --breadcrumbs-font-size: 14px;
 
   /* comwrap styles  */
     /* Spacing */


### PR DESCRIPTION
Managed to show the breadcrumb block in the pages. The missing visualization was due to the tidyDOM function that removed the meta tag from the head of the page. We just added 'breadcrumb' to the ignored list.
We added also a couple of css variables to manage the correct visualization of the element.

The breadcrumb is activated by adding the following Metadata section at the end of the doc:
![image](https://github.com/ComwrapUk/ComwrapBoilerplate/assets/10838972/b5f7f69d-de55-4d23-b9e7-7c1e8b1c694b)


Test URLs:
- Before: https://main--comwrapboilerplate--comwrapuk.hlx.page/en/uk/
- After: https://main--comwrapboilerplate--mrsambo93.hlx.page/en/uk/
